### PR TITLE
Improve compatibility with other mods

### DIFF
--- a/mods/egocaribautomapmarkers/src/Utilities/WaypointUtil.cs
+++ b/mods/egocaribautomapmarkers/src/Utilities/WaypointUtil.cs
@@ -30,7 +30,7 @@ namespace Egocarib.AutoMapMarkers.Utilities
         {
             ServerPlayer = serverPlayer;
             WorldMapManager serverWorldMapManager = MapMarkerMod.CoreServerAPI.ModLoader.GetModSystem<WorldMapManager>();
-            WaypointMapLayer = serverWorldMapManager.MapLayers.FirstOrDefault((MapLayer ml) => ml.GetType() == typeof(WaypointMapLayer)) as WaypointMapLayer;
+            WaypointMapLayer = serverWorldMapManager.MapLayers.FirstOrDefault((MapLayer ml) => ml is WaypointMapLayer) as WaypointMapLayer;
         }
 
         /// <summary>


### PR DESCRIPTION
The expression `GetType() == typeof(WaypointMapLayer)` doesn't work when WaypointMapLayer is replaced with a derived class.

Replaced it with an `is` expression so that it properly works with derived classes.