### PR TITLE
 Support client-side-only install (no server-side mod required)

### DIFF
--- a/mods/automapmarkers/README.md
+++ b/mods/automapmarkers/README.md
@@ -3,6 +3,7 @@
 Automatically adds map markers to your map when you harvest certain objects or find loose ore. Fully configurable.
 
 Links:
- - [Vintage Story ModsDB](https://mods.vintagestory.at/automapmarkers)
- - [Vintage Story Mod Releases Forum](https://www.vintagestory.at/forums/topic/4989-resin-auto-map-markers/)
- - [Translations Hub (Crowdin)](https://crowdin.com/project/egocaribs-vintage-story-mods/invite?h=ea6a24150eea0f7b0def3b4284610db51948584)
+
+- [Vintage Story ModsDB](https://mods.vintagestory.at/automapmarkers)
+- [Vintage Story Mod Releases Forum](https://www.vintagestory.at/forums/topic/4989-resin-auto-map-markers/)
+- [Translations Hub (Crowdin)](https://crowdin.com/project/egocaribs-vintage-story-mods/invite?h=ea6a24150eea0f7b0def3b4284610db51948584)

--- a/mods/automapmarkers/automapmarkers.csproj
+++ b/mods/automapmarkers/automapmarkers.csproj
@@ -57,6 +57,9 @@
   <Content Include="modinfo.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
   </Content>
+  <Content Include="modicon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </Content>
   <EmbeddedResource Include="resources\_core.json" />
 </ItemGroup>
 

--- a/mods/automapmarkers/modinfo.json
+++ b/mods/automapmarkers/modinfo.json
@@ -4,8 +4,8 @@
   "name": "Auto Map Markers",
   "authors": [ "egocarib" ],
   "description": "Adds map markers to your map when you interact with certain objects. Fully configurable.",
-  "version": "5.0.3",
-  "requiredOnServer": true,
+  "version": "5.1.0",
+  "requiredOnServer": false,
   "requiredOnClient":  true,
   "dependencies": {
     "game": "1.22.0"

--- a/mods/automapmarkers/src/Compat/ClientBehaviorInjector.cs
+++ b/mods/automapmarkers/src/Compat/ClientBehaviorInjector.cs
@@ -1,0 +1,156 @@
+using Egocarib.AutoMapMarkers.Utilities;
+using System;
+using System.Collections.Generic;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Datastructures;
+using HarvestBehavior = Egocarib.AutoMapMarkers.BlockBehavior.HarvestMarkerBehavior;
+using LooseOreBehavior = Egocarib.AutoMapMarkers.BlockBehavior.LooseOresMarkerBehavior;
+using TraderBehavior = Egocarib.AutoMapMarkers.EntityBehavior.TraderMarkerBehavior;
+using VSBlockBehavior = Vintagestory.API.Common.BlockBehavior;
+
+namespace Egocarib.AutoMapMarkers.Compat
+{
+    /// <summary>
+    /// Attaches this mod's marker behaviors to blocks and entities from the client side.
+    /// </summary>
+    /// <remarks>
+    /// The behaviors are normally attached by the JSON patches in assets/automapmarkers/patches,
+    /// which are all "side": "server". That works because the server sends its block and entity
+    /// types (behaviors included) down to the client on join - but it also means the behaviors are
+    /// missing entirely when the mod isn't installed on the server.
+    ///
+    /// Client-side JSON patching doesn't help either, for the same reason: in multiplayer the
+    /// client's block and entity types come from the server's packets, not from the client's own
+    /// parsed assets. So the behaviors are added here instead, after the types have arrived.
+    ///
+    /// The HasBehavior guards make this a no-op when the server does have the mod, so this runs
+    /// unconditionally and only fills the gap when there is one.
+    /// </remarks>
+    public static class ClientBehaviorInjector
+    {
+        /// <summary>
+        /// Block code prefixes matching the JSON patches, and the behavior each one gets:
+        ///   "fruitingbush-"  from patches/fruitingbush.json  (blocktypes/plant/fruitingbush)
+        ///   "log-resin"      from patches/log-withresin.json (covers log-resin-* and
+        ///                    log-resinharvested-*, matching that patch's "/behaviorsByType/*/-")
+        ///   "looseores-"     from patches/looseores.json     (blocktypes/stone/looseores)
+        /// </summary>
+        private static readonly (string prefix, Type behaviorType)[] BlockTargets =
+        {
+            ("fruitingbush-", typeof(HarvestBehavior)),
+            ("log-resin", typeof(HarvestBehavior)),
+            ("looseores-", typeof(LooseOreBehavior)),
+        };
+
+        private const string TraderBehaviorName = "egocarib_TraderMarkerBehavior";
+        private const string TraderCodePrefix = "trader-";
+
+        private static ICoreClientAPI clientAPI;
+
+        /// <summary>
+        /// Registers the injector. Blocks are handled once the world is loaded; traders are handled
+        /// per entity, since entity behaviors are built when each entity is created.
+        /// </summary>
+        public static void Register(ICoreClientAPI capi)
+        {
+            if (capi == null)
+                return;
+
+            clientAPI = capi;
+            capi.Event.LevelFinalize += InjectBlockBehaviors;
+            capi.Event.OnEntityLoaded += InjectTraderBehavior;
+            capi.Event.OnEntitySpawn += InjectTraderBehavior;
+        }
+
+        public static void Unregister(ICoreClientAPI capi)
+        {
+            if (capi?.Event != null)
+            {
+                capi.Event.LevelFinalize -= InjectBlockBehaviors;
+                capi.Event.OnEntityLoaded -= InjectTraderBehavior;
+                capi.Event.OnEntitySpawn -= InjectTraderBehavior;
+            }
+            clientAPI = null;
+        }
+
+        private static void InjectBlockBehaviors()
+        {
+            if (clientAPI?.World?.Blocks == null)
+                return;
+
+            int injected = 0;
+            foreach (Block block in clientAPI.World.Blocks)
+            {
+                string path = block?.Code?.Path;
+                if (string.IsNullOrEmpty(path))
+                    continue;
+
+                foreach (var (prefix, behaviorType) in BlockTargets)
+                {
+                    if (!path.StartsWith(prefix, StringComparison.Ordinal))
+                        continue;
+                    if (block.HasBehavior(behaviorType, withInheritance: false))
+                        break;  // Already attached - the server has the mod and patched it in
+
+                    if (TryAddBlockBehavior(block, behaviorType))
+                        injected++;
+                    break;
+                }
+            }
+
+            if (injected > 0)
+                MessageUtil.Log($"Attached map marker behaviors to {injected} block types client-side.");
+        }
+
+        /// <summary>
+        /// Appends a block behavior the way the game's own Block.CreateBehaviors does - block
+        /// behaviors live in both BlockBehaviors and CollectibleBehaviors. Appending (rather than
+        /// inserting) matches the "/behaviors/-" position used by the JSON patches, so behavior
+        /// precedence is unchanged.
+        /// </summary>
+        private static bool TryAddBlockBehavior(Block block, Type behaviorType)
+        {
+            try
+            {
+                var behavior = (VSBlockBehavior)Activator.CreateInstance(behaviorType, block);
+                behavior.Initialize(new Vintagestory.API.Datastructures.JsonObject(
+                    new Newtonsoft.Json.Linq.JObject()));
+
+                block.BlockBehaviors = Append(block.BlockBehaviors, behavior);
+                block.CollectibleBehaviors = Append(block.CollectibleBehaviors, behavior);
+                return true;
+            }
+            catch (Exception e)
+            {
+                MessageUtil.LogError($"Unable to attach {behaviorType.Name} to block {block.Code} - {e.Message}");
+                return false;
+            }
+        }
+
+        private static T[] Append<T>(T[] existing, T value)
+        {
+            var list = new List<T>(existing ?? Array.Empty<T>()) { value };
+            return list.ToArray();
+        }
+
+        private static void InjectTraderBehavior(Entity entity)
+        {
+            string path = entity?.Code?.Path;
+            if (path == null || !path.StartsWith(TraderCodePrefix, StringComparison.Ordinal))
+                return;
+            if (entity.HasBehavior(TraderBehaviorName))
+                return;  // Already attached - the server has the mod and patched it in
+
+            try
+            {
+                entity.AddBehavior(new TraderBehavior(entity));
+            }
+            catch (Exception e)
+            {
+                MessageUtil.LogError($"Unable to attach trader marker behavior to {entity.Code} - {e.Message}");
+            }
+        }
+    }
+}

--- a/mods/automapmarkers/src/MapMarkerMod.cs
+++ b/mods/automapmarkers/src/MapMarkerMod.cs
@@ -1,9 +1,11 @@
 ﻿using Egocarib.AutoMapMarkers.BlockBehavior;
+using Egocarib.AutoMapMarkers.Compat;
 using Egocarib.AutoMapMarkers.EntityBehavior;
 using Egocarib.AutoMapMarkers.Events;
 using Egocarib.AutoMapMarkers.Network;
 using Egocarib.AutoMapMarkers.Patches;
 using Egocarib.AutoMapMarkers.Settings;
+using Egocarib.AutoMapMarkers.Waypoints;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Server;
@@ -26,7 +28,7 @@ namespace Egocarib.AutoMapMarkers
             CoreAPI.RegisterEntityBehaviorClass("egocarib_TraderMarkerBehavior", typeof(TraderMarkerBehavior));
             CoreAPI.RegisterBlockBehaviorClass("egocarib_HarvestMarkerBehavior", typeof(HarvestMarkerBehavior));
             CoreAPI.RegisterBlockBehaviorClass("egocarib_LooseOreMarkerBehavior", typeof(LooseOresMarkerBehavior));
-            HarmonyAgent.Harmonize();
+            HarmonyAgent.Harmonize(api.Side);
         }
 
         /// <summary>
@@ -48,6 +50,8 @@ namespace Egocarib.AutoMapMarkers
             MapMarkerConfig.InitializeDefinitions(api);
             api.Event.BlockTexturesLoaded += () => MapMarkerConfig.RunDeferredConflictCheck(api);
             Network = new MapMarkerNetwork(CoreClientAPI);
+            ClientWaypointCommands.Initialize(api);
+            ClientBehaviorInjector.Register(api);
             CoreClientAPI.Input.InWorldAction += DetectionHandler.HandlePlayerSneak;
         }
 
@@ -61,6 +65,9 @@ namespace Egocarib.AutoMapMarkers
             {
                 if (CoreClientAPI.Input != null)
                     CoreClientAPI.Input.InWorldAction -= DetectionHandler.HandlePlayerSneak;
+                ClientWaypointCommands.Dispose(CoreClientAPI);
+                ClientBehaviorInjector.Unregister(CoreClientAPI);
+                ClientWaypointAccess.Reset();
                 CoreClientAPI = null;
             }
             CoreAPI = null;

--- a/mods/automapmarkers/src/Network/MapMarkerNetwork.cs
+++ b/mods/automapmarkers/src/Network/MapMarkerNetwork.cs
@@ -1,5 +1,6 @@
 ﻿using Egocarib.AutoMapMarkers.Settings;
 using Egocarib.AutoMapMarkers.Utilities;
+using Egocarib.AutoMapMarkers.Waypoints;
 using ProtoBuf;
 using System;
 using System.IO;
@@ -58,12 +59,27 @@ namespace Egocarib.AutoMapMarkers.Network
     }
 
     /// <summary>
-    /// Network handler for Auto Map Markers mod. Facilitates communication between the
-    /// client, which may request that a waypoint be created, and the server, which creates 
-    /// the waypoints and syncs them back to the client.
+    /// Waypoint request handler for Auto Map Markers mod.
     /// </summary>
+    /// <remarks>
+    /// When the mod is installed on the server, this facilitates communication between the client,
+    /// which may request that a waypoint be created, and the server, which creates the waypoints and
+    /// syncs them back to the client.
+    ///
+    /// When the mod is not installed on the server, requests are instead fulfilled entirely
+    /// client-side by <see cref="ClientWaypointCommands"/>, which drives the vanilla waypoint chat
+    /// commands. The transport is chosen per request; detection code doesn't need to care which one
+    /// is in use.
+    /// </remarks>
     public class MapMarkerNetwork
     {
+        /// <summary>
+        /// Set the AUTOMAPMARKERS_FORCE_CLIENT environment variable to exercise the client-side
+        /// waypoint path in single player, where the integrated server always has the mod.
+        /// </summary>
+        private static readonly bool ForceClientSideWaypoints =
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AUTOMAPMARKERS_FORCE_CLIENT"));
+
         public EnumAppSide Side;
         public ICoreAPI CoreAPI;
         public IServerNetworkChannel ServerNetworkChannel;
@@ -73,7 +89,14 @@ namespace Egocarib.AutoMapMarkers.Network
         private const int MaxConnectionAttempts = 9;
         private Timer ClientHandshakeTimer;
         private int ConnectionCheckAttempts = 0;
-        private bool ConnectionWarningSent = false;
+        private bool FallbackModeLogged = false;
+
+        /// <summary>
+        /// True when the mod is present on the server and its channel is available, meaning waypoint
+        /// requests can be handled directly by <see cref="WaypointUtil"/> on the server.
+        /// </summary>
+        private bool UseServerChannel =>
+            !ForceClientSideWaypoints && ClientNetworkChannel?.Connected == true;
 
         public MapMarkerNetwork(ICoreAPI api)
         {
@@ -208,9 +231,13 @@ namespace Egocarib.AutoMapMarkers.Network
         }
 
         /// <summary>
-        /// Validates that a client request can proceed: correct side, mod enabled, channel connected.
+        /// Validates that a client request can proceed: correct side, mod enabled.
         /// Returns the current mod settings if valid, or null if the request should be aborted.
         /// </summary>
+        /// <remarks>
+        /// Connectivity is deliberately not checked here - a missing server-side mod is not a failure,
+        /// it just selects the client-side transport instead.
+        /// </remarks>
         private MapMarkerConfig.Settings ValidateClientRequest(string operationName)
         {
             if (Side != EnumAppSide.Client)
@@ -224,16 +251,12 @@ namespace Egocarib.AutoMapMarkers.Network
                 MessageUtil.Log($"Suppressed {operationName} - mod features are currently disabled.");
                 return null;
             }
-            if (!ClientNetworkChannel.Connected)
-            {
-                MessageUtil.LogError($"Not connected to mod instance on server - unable to perform {operationName}.");
-                return null;
-            }
             return modSettings;
         }
 
         /// <summary>
-        /// Method called by a client to request that the server create a waypoint on behalf of the client.
+        /// Method called by a client to request the creation of a waypoint. Handled by the server if
+        /// the mod is installed there, otherwise by the client itself.
         /// </summary>
         /// <remarks>
         /// Side: client only
@@ -242,6 +265,13 @@ namespace Egocarib.AutoMapMarkers.Network
         {
             var modSettings = ValidateClientRequest("map marker creation");
             if (modSettings == null) return;
+
+            if (!UseServerChannel)
+            {
+                ClientWaypointCommands.AddWaypoint(position, settings, sendChatMessage,
+                    dynamicTitleComponent, modSettings.LabelCoordinates);
+                return;
+            }
 
             var waypointRequest = new ClientWaypointRequest
             {
@@ -255,7 +285,7 @@ namespace Egocarib.AutoMapMarkers.Network
         }
 
         /// <summary>
-        /// Method called by a client to request that the server delete a waypoint on behalf of the client.
+        /// Method called by a client to request the deletion of the waypoint nearest to the player.
         /// </summary>
         /// <remarks>
         /// Side: client only
@@ -263,6 +293,12 @@ namespace Egocarib.AutoMapMarkers.Network
         public void RequestNearestWaypointDeletionFromServer(bool sendChatMessage)
         {
             if (ValidateClientRequest("map marker deletion") == null) return;
+
+            if (!UseServerChannel)
+            {
+                ClientWaypointCommands.DeleteNearestWaypoint(sendChatMessage);
+                return;
+            }
 
             var waypointRequest = new ClientWaypointDeleteRequest
             {
@@ -272,7 +308,7 @@ namespace Egocarib.AutoMapMarkers.Network
         }
 
         /// <summary>
-        /// Method called by a client to request that the server delete a waypoint at a specific position
+        /// Method called by a client to request the deletion of a waypoint at a specific position
         /// matching a title pattern, within a given radius.
         /// </summary>
         /// <remarks>
@@ -281,6 +317,13 @@ namespace Egocarib.AutoMapMarkers.Network
         public void RequestWaypointDeletionAtPositionFromServer(Vec3d position, bool sendChatMessage, string titlePattern, double maxRadius)
         {
             if (ValidateClientRequest("map marker deletion") == null) return;
+
+            if (!UseServerChannel)
+            {
+                ClientWaypointCommands.DeleteNearestWaypoint(sendChatMessage, position, titlePattern,
+                    maxRadius > 0 ? maxRadius : double.MaxValue);
+                return;
+            }
 
             var waypointRequest = new ClientWaypointDeleteRequest
             {
@@ -293,7 +336,9 @@ namespace Egocarib.AutoMapMarkers.Network
         }
 
         /// <summary>
-        /// Initiates a handshake with the server to confirm that the mod is installed on the server.
+        /// Initiates a handshake with the server to determine whether the mod is installed there.
+        /// The result decides whether the mod's own network channel or the client-side waypoint
+        /// commands are used, and whether default settings can be downloaded from the server.
         /// </summary>
         /// <remarks>
         /// Side: client only
@@ -329,15 +374,12 @@ namespace Egocarib.AutoMapMarkers.Network
             }
             else if (++ConnectionCheckAttempts > MaxConnectionAttempts)
             {
-                var clientAPI = CoreAPI as ICoreClientAPI;
-                if (clientAPI == null || clientAPI.IsSinglePlayer == false)
+                if (!FallbackModeLogged)
                 {
-                    if (!ConnectionWarningSent)
-                    {
-                        ConnectionWarningSent = true;  // Ensure only a single chat warning appears
-                        MessageUtil.Chat(Lang.Get("egocarib-mapmarkers:server-warning"));
-                        MapMarkerConfig.GetSettings(CoreAPI); //Ensure that a config file is generated
-                    }
+                    FallbackModeLogged = true;
+                    MessageUtil.Log("Mod is not installed on the server - map markers will be created"
+                        + " client-side using the game's waypoint commands.");
+                    MapMarkerConfig.GetSettings(CoreAPI); //Ensure that a config file is generated
                 }
             }
             else

--- a/mods/automapmarkers/src/Patches/ChatSuppression.cs
+++ b/mods/automapmarkers/src/Patches/ChatSuppression.cs
@@ -1,0 +1,212 @@
+using Egocarib.AutoMapMarkers.Utilities;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+
+namespace Egocarib.AutoMapMarkers.Patches
+{
+    /// <summary>
+    /// Hides the vanilla server's waypoint command confirmations when they were caused by an
+    /// automatic map marker.
+    /// </summary>
+    /// <remarks>
+    /// When the mod isn't installed on the server, markers are created by sending the vanilla
+    /// "/waypoint addati ..." chat command. The server answers every one of those with a chat line
+    /// ("Ok, waypoint nr. 12 added"), which would turn routine berry picking into chat spam.
+    ///
+    /// This can't be done through ICoreClientAPI.Event.ChatMessage - that event uses ChatLineDelegate,
+    /// which has no way to cancel a message (only the outgoing OnSendChatMessage event does). So the
+    /// client's chat line handler gets a Harmony prefix instead.
+    ///
+    /// Suppression is deliberately narrow: it only applies while a command we sent is awaiting its
+    /// reply, only to command success/error lines, and only to messages matching the game's own
+    /// waypoint command responses in the active language.
+    /// </remarks>
+    public static class ChatSuppression
+    {
+        /// <summary>
+        /// How long after sending a command we are willing to swallow its reply.
+        /// </summary>
+        private const long SuppressionWindowMs = 5000;
+
+        /// <summary>
+        /// Lang keys for every response the vanilla waypoint add/remove commands can produce.
+        /// Suppressing the failures too keeps a misconfigured marker from spamming chat; the
+        /// suppressed text is written to the client log instead.
+        /// </summary>
+        private static readonly string[] SuppressedLangKeys =
+        {
+            "Ok, waypoint nr. {0} added",
+            "Ok, deleted waypoint.",
+            "You have no waypoints to delete",
+            "No such waypoint found",
+            "Invalid waypoint number, valid ones are 0..{0}",
+            "command-modwaypoint-invalidindex",
+            "command-waypoint-invalidcolor",
+            "command-waypoint-notext",
+            "Invalid position. Syntax: /waypoint addati icon x y z pinned color title",
+        };
+
+        private static Regex[] suppressedPatterns;
+        private static int pendingReplies;
+        private static long suppressUntilMs;
+        private static bool patchApplied;
+
+        /// <summary>
+        /// Marks that a waypoint command has just been sent and its reply should be hidden.
+        /// </summary>
+        public static void ArmSuppression()
+        {
+            var capi = MapMarkerMod.CoreClientAPI;
+            if (capi == null || !patchApplied)
+                return;
+
+            pendingReplies++;
+            suppressUntilMs = capi.World.ElapsedMilliseconds + SuppressionWindowMs;
+        }
+
+        /// <summary>
+        /// Applies the prefix. Safe to call when the game's internals have moved: it logs and gives
+        /// up, leaving the mod fully functional but chattier.
+        /// </summary>
+        public static void ApplyPatch(Harmony harmony)
+        {
+            if (patchApplied || harmony == null)
+                return;
+
+            MethodInfo target = ResolveTarget();
+            if (target == null)
+            {
+                MessageUtil.Log("Could not find the client's chat line handler. Waypoint confirmations from"
+                    + " the server will be visible in chat.");
+                return;
+            }
+
+            try
+            {
+                var prefix = new HarmonyMethod(typeof(ChatSuppression).GetMethod(
+                    nameof(SuppressWaypointReplyPrefix), BindingFlags.NonPublic | BindingFlags.Static));
+                harmony.Patch(target, prefix: prefix);
+                patchApplied = true;
+            }
+            catch (Exception e)
+            {
+                MessageUtil.LogError($"Unable to suppress server waypoint confirmations - {e.Message}");
+            }
+        }
+
+        public static void Reset()
+        {
+            patchApplied = false;
+            pendingReplies = 0;
+            suppressUntilMs = 0;
+            suppressedPatterns = null;
+        }
+
+        /// <summary>
+        /// Both candidates take (int groupId, string message, EnumChatType chattype, string data).
+        /// The chat HUD's own handler is preferred because blocking there leaves the message visible
+        /// to other mods listening on ICoreClientAPI.Event.ChatMessage; the event manager's trigger
+        /// is the fallback if that private method is ever renamed.
+        /// </summary>
+        private static MethodInfo ResolveTarget()
+        {
+            var candidates = new (string typeName, string methodName)[]
+            {
+                ("Vintagestory.Client.NoObf.HudDialogChat", "OnNewServerToClientChatLine"),
+                ("Vintagestory.Client.NoObf.ClientEventManager", "TriggerNewServerChatLine"),
+            };
+
+            foreach (var (typeName, methodName) in candidates)
+            {
+                Type type = AccessTools.TypeByName(typeName);
+                if (type == null)
+                    continue;
+
+                MethodInfo method = AccessTools.Method(type, methodName,
+                    new[] { typeof(int), typeof(string), typeof(EnumChatType), typeof(string) });
+                if (method != null)
+                    return method;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Harmony prefix. Parameters are taken positionally (__1 / __2) because the two candidate
+        /// targets spell their parameters differently ("groupId" vs "groupid").
+        /// </summary>
+        private static bool SuppressWaypointReplyPrefix(string __1, EnumChatType __2)
+        {
+            try
+            {
+                if (!ShouldSuppress(__1, __2))
+                    return true;
+
+                pendingReplies--;
+                MessageUtil.Log($"Suppressed waypoint command reply: \"{__1}\"");
+                return false;
+            }
+            catch (Exception)
+            {
+                return true;  // Never let a suppression bug swallow the player's chat
+            }
+        }
+
+        private static bool ShouldSuppress(string message, EnumChatType chatType)
+        {
+            if (pendingReplies <= 0 || string.IsNullOrEmpty(message))
+                return false;
+            if (chatType != EnumChatType.CommandSuccess && chatType != EnumChatType.CommandError)
+                return false;
+
+            var capi = MapMarkerMod.CoreClientAPI;
+            if (capi == null)
+                return false;
+
+            if (capi.World.ElapsedMilliseconds > suppressUntilMs)
+            {
+                pendingReplies = 0;  // Replies we were waiting for never arrived; stop watching
+                return false;
+            }
+
+            foreach (Regex pattern in GetSuppressedPatterns())
+            {
+                if (pattern.IsMatch(message))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Builds match patterns from the translated command responses, so suppression works in
+        /// whatever language the client is running. "{0}" placeholders become wildcards.
+        /// </summary>
+        private static Regex[] GetSuppressedPatterns()
+        {
+            if (suppressedPatterns != null)
+                return suppressedPatterns;
+
+            var patterns = new List<Regex>();
+            foreach (string key in SuppressedLangKeys)
+            {
+                string translated = Lang.GetUnformatted(key);
+                if (string.IsNullOrEmpty(translated))
+                    continue;
+
+                // Regex.Escape turns "{0}" into "\{0}"; turn those placeholders back into wildcards.
+                string regex = "^" + Regex.Escape(translated) + "$";
+                regex = Regex.Replace(regex, @"\\\{\d+\}", ".*");
+                patterns.Add(new Regex(regex, RegexOptions.Compiled));
+            }
+
+            suppressedPatterns = patterns.ToArray();
+            return suppressedPatterns;
+        }
+    }
+}

--- a/mods/automapmarkers/src/Patches/HarmonyAgent.cs
+++ b/mods/automapmarkers/src/Patches/HarmonyAgent.cs
@@ -1,6 +1,7 @@
 ﻿using Egocarib.AutoMapMarkers.Utilities;
 using HarmonyLib;
 using System.Reflection;
+using Vintagestory.API.Common;
 
 namespace Egocarib.AutoMapMarkers.Patches
 {
@@ -12,20 +13,30 @@ namespace Egocarib.AutoMapMarkers.Patches
         /// <summary>
         /// Applies the mod's Harmony patches.
         /// </summary>
-        public static void Harmonize()
+        public static void Harmonize(EnumAppSide side)
         {
             if (harmonyInstance == null)
             {
                 harmonyInstance = new Harmony(harmonyID);
                 harmonyInstance.PatchAll(Assembly.GetAssembly(typeof(HarmonyAgent)));
-                string patchedMethods = "";
-                foreach (var method in harmonyInstance.GetPatchedMethods())
-                {
-                    patchedMethods += string.IsNullOrEmpty(patchedMethods) ? "" : ", ";
-                    patchedMethods += method.Name;
-                }
-                MessageUtil.Log("Patched methods: " + patchedMethods);
             }
+
+            // Chat suppression targets a method resolved at runtime, so it can't go through PatchAll,
+            // and it only makes sense on the client. This sits outside the guard above because in
+            // single player both sides share this static Harmony instance and the server side gets
+            // here first, which would otherwise skip the client patch entirely.
+            if (side == EnumAppSide.Client)
+            {
+                ChatSuppression.ApplyPatch(harmonyInstance);
+            }
+
+            string patchedMethods = "";
+            foreach (var method in harmonyInstance.GetPatchedMethods())
+            {
+                patchedMethods += string.IsNullOrEmpty(patchedMethods) ? "" : ", ";
+                patchedMethods += method.Name;
+            }
+            MessageUtil.Log("Patched methods: " + patchedMethods);
         }
 
         /// <summary>
@@ -35,6 +46,7 @@ namespace Egocarib.AutoMapMarkers.Patches
         {
             harmonyInstance?.UnpatchAll(harmonyID);
             harmonyInstance = null;
+            ChatSuppression.Reset();
         }
     }
 }

--- a/mods/automapmarkers/src/Waypoints/ClientWaypointAccess.cs
+++ b/mods/automapmarkers/src/Waypoints/ClientWaypointAccess.cs
@@ -1,0 +1,209 @@
+using Egocarib.AutoMapMarkers.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vintagestory.API.Client;
+using Vintagestory.API.MathTools;
+using Vintagestory.GameContent;
+
+namespace Egocarib.AutoMapMarkers.Waypoints
+{
+    /// <summary>
+    /// Read-only, client-side access to the vanilla waypoint map layer.
+    /// </summary>
+    /// <remarks>
+    /// The client instance of <see cref="WaypointMapLayer"/> keeps the player's own waypoints in its
+    /// public "ownWaypoints" list, populated whenever the server sends a waypoint sync. Reading it
+    /// lets the client-side command path deduplicate markers and resolve waypoint indices for
+    /// deletion without any server-side mod component.
+    ///
+    /// Because the server only re-syncs after it has processed our chat command, waypoints we just
+    /// asked for are invisible here for a short while. <see cref="AddPending"/> covers that window.
+    /// </remarks>
+    public static class ClientWaypointAccess
+    {
+        /// <summary>
+        /// A waypoint the client has requested but which the server has not synced back yet.
+        /// </summary>
+        public class PendingWaypoint
+        {
+            public Vec3d Position;
+            public string Title;
+            public string Icon;
+            public int? Color;
+            public long ExpiresAtMs;
+        }
+
+        private const long PendingLifetimeMs = 30000;
+
+        private static WaypointMapLayer cachedLayer;
+        private static readonly List<PendingWaypoint> pendingWaypoints = new List<PendingWaypoint>();
+        private static readonly Dictionary<string, long> pendingDeletionKeys = new Dictionary<string, long>();
+        private static bool layerFailureLogged;
+
+        /// <summary>
+        /// Stable identity for a waypoint across server re-syncs, which replace the Waypoint objects
+        /// wholesale. Guid is server-assigned; waypoints from old saves may not have one.
+        /// </summary>
+        public static string KeyOf(Waypoint waypoint)
+        {
+            if (waypoint == null)
+                return null;
+            if (!string.IsNullOrEmpty(waypoint.Guid))
+                return waypoint.Guid;
+            return $"{waypoint.Position?.X}/{waypoint.Position?.Y}/{waypoint.Position?.Z}/{waypoint.Title}";
+        }
+
+        /// <summary>
+        /// Locates the client-side waypoint map layer. Uses the same lookup as
+        /// MapMarkerGUI.LoadColorOptions and WaypointUtil.
+        /// </summary>
+        public static WaypointMapLayer GetLayer()
+        {
+            if (cachedLayer != null)
+                return cachedLayer;
+
+            ICoreClientAPI capi = MapMarkerMod.CoreClientAPI;
+            if (capi == null)
+                return null;
+
+            List<MapLayer> mapLayers = capi.ModLoader?.GetModSystem<WorldMapManager>()?.MapLayers;
+            cachedLayer = mapLayers?.FirstOrDefault((MapLayer l) => l is WaypointMapLayer) as WaypointMapLayer;
+
+            if (cachedLayer == null && !layerFailureLogged)
+            {
+                layerFailureLogged = true;
+                MessageUtil.LogError("Unable to locate the game's waypoint map layer. Client-side map markers"
+                    + " will still be created, but duplicate detection and marker deletion won't work.");
+            }
+
+            return cachedLayer;
+        }
+
+        /// <summary>
+        /// Returns the waypoints owned by this player, in the same order the server keeps them.
+        /// That order is what the "/waypoint remove [index]" command indexes into.
+        /// Returns an empty list if the waypoint layer isn't reachable.
+        /// </summary>
+        public static List<Waypoint> GetOwnWaypoints()
+        {
+            var result = new List<Waypoint>();
+
+            ICoreClientAPI capi = MapMarkerMod.CoreClientAPI;
+            string playerUid = capi?.World?.Player?.PlayerUID;
+            List<Waypoint> ownWaypoints = GetLayer()?.ownWaypoints;
+            if (playerUid == null || ownWaypoints == null)
+                return result;
+
+            foreach (Waypoint waypoint in ownWaypoints)
+            {
+                if (waypoint != null && waypoint.OwningPlayerUid == playerUid)
+                    result.Add(waypoint);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Records that we have asked the server to delete a waypoint, but the deletion hasn't been
+        /// reflected in a sync yet.
+        /// </summary>
+        public static void AddPendingDeletion(Waypoint waypoint)
+        {
+            ICoreClientAPI capi = MapMarkerMod.CoreClientAPI;
+            string key = KeyOf(waypoint);
+            if (capi == null || key == null)
+                return;
+
+            pendingDeletionKeys[key] = capi.World.ElapsedMilliseconds + PendingLifetimeMs;
+        }
+
+        /// <summary>
+        /// True if we have already asked the server to delete this waypoint. Deletion commands are
+        /// queued and sent at a fixed rate, so without this a later request could target a waypoint
+        /// that is already on its way out, or compute an index the earlier deletion invalidates.
+        /// </summary>
+        public static bool IsPendingDeletion(Waypoint waypoint)
+        {
+            string key = KeyOf(waypoint);
+            if (key == null || !pendingDeletionKeys.TryGetValue(key, out long expiresAt))
+                return false;
+
+            ICoreClientAPI capi = MapMarkerMod.CoreClientAPI;
+            if (capi == null || capi.World.ElapsedMilliseconds > expiresAt)
+            {
+                pendingDeletionKeys.Remove(key);
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Records a waypoint we just requested, so that a second detection arriving before the
+        /// server's sync doesn't create a duplicate.
+        /// </summary>
+        public static void AddPending(Vec3d position, string title, string icon, int? color)
+        {
+            ICoreClientAPI capi = MapMarkerMod.CoreClientAPI;
+            if (capi == null || position == null)
+                return;
+
+            pendingWaypoints.Add(new PendingWaypoint
+            {
+                Position = position.Clone(),
+                Title = title,
+                Icon = icon,
+                Color = color,
+                ExpiresAtMs = capi.World.ElapsedMilliseconds + PendingLifetimeMs
+            });
+        }
+
+        /// <summary>
+        /// Pending waypoints that are still unconfirmed. Expired entries, and entries the server has
+        /// since echoed back, are dropped as a side effect.
+        /// </summary>
+        public static List<PendingWaypoint> GetPending()
+        {
+            ICoreClientAPI capi = MapMarkerMod.CoreClientAPI;
+            if (capi == null || pendingWaypoints.Count == 0)
+                return pendingWaypoints;
+
+            long now = capi.World.ElapsedMilliseconds;
+            List<Waypoint> ownWaypoints = GetOwnWaypoints();
+
+            pendingWaypoints.RemoveAll(pending =>
+                pending.ExpiresAtMs <= now
+                || ownWaypoints.Any(wp => wp.Position != null
+                    && wp.Position.SquareDistanceTo(pending.Position) < 1.0
+                    && WaypointUtil.MatchingWaypointTitle(wp.Title, pending.Title)));
+
+            return pendingWaypoints;
+        }
+
+        /// <summary>
+        /// Forgets any pending entry near the given position, used after a deletion request so a
+        /// re-created marker isn't suppressed by its own stale pending record.
+        /// </summary>
+        public static void DropPendingNear(Vec3d position, double radius)
+        {
+            if (position == null)
+                return;
+
+            pendingWaypoints.RemoveAll(pending =>
+                Math.Max(
+                    Math.Abs(pending.Position.X - position.X),
+                    Math.Abs(pending.Position.Z - position.Z)) < radius);
+        }
+
+        /// <summary>
+        /// Clears cached state. Called when the mod is disposed.
+        /// </summary>
+        public static void Reset()
+        {
+            cachedLayer = null;
+            pendingWaypoints.Clear();
+            pendingDeletionKeys.Clear();
+            layerFailureLogged = false;
+        }
+    }
+}

--- a/mods/automapmarkers/src/Waypoints/ClientWaypointCommands.cs
+++ b/mods/automapmarkers/src/Waypoints/ClientWaypointCommands.cs
@@ -1,0 +1,331 @@
+using Egocarib.AutoMapMarkers.Patches;
+using Egocarib.AutoMapMarkers.Settings;
+using Egocarib.AutoMapMarkers.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Vintagestory.API.Client;
+using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
+using Vintagestory.GameContent;
+using static Egocarib.AutoMapMarkers.Settings.MapMarkerConfig.Settings;
+
+namespace Egocarib.AutoMapMarkers.Waypoints
+{
+    /// <summary>
+    /// Creates and deletes waypoints from the client alone, using the vanilla waypoint chat commands.
+    /// This is the path used when the mod isn't installed on the server.
+    /// </summary>
+    /// <remarks>
+    /// Waypoints are owned by the server and there is no client-authoritative API for them, but the
+    /// game's own "Add waypoint" dialog creates them by sending a chat command - so the same commands
+    /// work from a mod with nothing installed server-side:
+    ///
+    ///     /waypoint addati [icon] =[x] =[y] =[z] [pinned] [color] [title]
+    ///     /waypoint remove [index]
+    ///
+    /// The "=" prefix marks the coordinate as absolute rather than relative to world spawn.
+    ///
+    /// This mirrors the decision logic of <see cref="WaypointUtil"/>, which does the same job on the
+    /// server when the mod is installed there.
+    /// </remarks>
+    public static class ClientWaypointCommands
+    {
+        private const int SendIntervalMs = 150;
+        private const int MaxQueuedCommands = 50;
+
+        private class QueuedCommand
+        {
+            public string Command;
+            public bool SuppressServerReply;
+        }
+
+        private static readonly List<QueuedCommand> commandQueue = new List<QueuedCommand>();
+        private static long tickListenerId;
+        private static bool queueOverflowLogged;
+
+        /// <summary>
+        /// Starts the outgoing command queue. Chat isn't a bulk transport, and a single scythe swing
+        /// can produce several markers at once, so commands are drained at a fixed rate.
+        /// </summary>
+        public static void Initialize(ICoreClientAPI capi)
+        {
+            if (capi == null)
+                return;
+
+            // Deferred to LevelFinalize because there is no world to tick against yet at mod startup.
+            capi.Event.LevelFinalize += () =>
+            {
+                if (tickListenerId == 0)
+                    tickListenerId = capi.Event.RegisterGameTickListener(DrainQueue, SendIntervalMs);
+            };
+        }
+
+        public static void Dispose(ICoreClientAPI capi)
+        {
+            if (capi != null && tickListenerId != 0)
+                capi.Event.UnregisterGameTickListener(tickListenerId);
+            tickListenerId = 0;
+            commandQueue.Clear();
+            queueOverflowLogged = false;
+        }
+
+        /// <summary>
+        /// Parses the provided map marker settings and determines whether a new waypoint should be
+        /// added at the specified coordinates, then asks the server to create it via chat command.
+        /// Client-side counterpart of <see cref="WaypointUtil.AddWaypoint"/>.
+        /// </summary>
+        public static void AddWaypoint(Vec3d position, AutoMapMarkerSetting settings, bool sendChatMessageToPlayer, string dynamicTitleComponent, bool includeCoordinates)
+        {
+            ICoreClientAPI capi = MapMarkerMod.CoreClientAPI;
+            if (capi == null)
+                return;
+            if (position == null || settings == null)
+            {
+                MessageUtil.LogError("Unable to create map marker - missing position or settings data.");
+                return;
+            }
+            if (!settings.Enabled)
+            {
+                return;
+            }
+
+            string title = WaypointUtil.FormatDynamicTitle(settings.MarkerTitle, dynamicTitleComponent);
+
+            if (includeCoordinates)
+            {
+                Vec3d playerFriendlyPos = position.Clone().Sub(capi.World.DefaultSpawnPosition.AsBlockPos);
+                title = $"{title}  [{playerFriendlyPos.XInt}, {position.YInt}, {playerFriendlyPos.ZInt}]";
+            }
+
+            title = SanitizeTitle(title);
+            if (string.IsNullOrEmpty(title) || string.IsNullOrEmpty(settings.MarkerIcon))
+            {
+                MessageUtil.LogError("Unable to create map marker - missing title or icon.");
+                return;
+            }
+
+            string icon = settings.MarkerIcon.Trim();
+            if (icon.Any(char.IsWhiteSpace))
+            {
+                MessageUtil.LogError($"Unable to create map marker - icon name \"{icon}\" contains whitespace.");
+                return;
+            }
+
+            string color = SanitizeColor(settings);
+            if (color == null)
+            {
+                MessageUtil.LogError("Unable to create map marker - invalid color.");
+                return;
+            }
+
+            if (IsCoveredByExistingWaypoint(position, title, icon, settings))
+            {
+                return;
+            }
+
+            // "/waypoint addati [icon] =[x] =[y] =[z] [pinned] [color] [title]"
+            string command = string.Format(CultureInfo.InvariantCulture,
+                "/waypoint addati {0} ={1} ={2} ={3} {4} {5} {6}",
+                icon,
+                position.X.ToString("0.##", CultureInfo.InvariantCulture),
+                position.Y.ToString("0.##", CultureInfo.InvariantCulture),
+                position.Z.ToString("0.##", CultureInfo.InvariantCulture),
+                settings.MarkerPinned,  // "True"/"False", matching what the game's own dialog sends
+                color,
+                title);
+
+            ClientWaypointAccess.AddPending(position, title, icon, settings.MarkerColorInteger);
+            Enqueue(command, sendChatMessageToPlayer);
+        }
+
+        /// <summary>
+        /// Finds the waypoint nearest to the specified position (or the player's current location if
+        /// null), optionally filtering by title pattern and max radius, then asks the server to
+        /// delete it. Client-side counterpart of <see cref="WaypointUtil.DeleteNearestWaypoint"/>.
+        /// </summary>
+        public static void DeleteNearestWaypoint(bool sendChatMessageToPlayer,
+            Vec3d targetPosition = null, string titlePattern = null, double maxRadius = double.MaxValue)
+        {
+            ICoreClientAPI capi = MapMarkerMod.CoreClientAPI;
+            if (capi?.World?.Player?.Entity == null)
+                return;
+
+            Vec3d searchPosition = targetPosition ?? capi.World.Player.Entity.Pos.XYZ;
+            List<Waypoint> ownWaypoints = ClientWaypointAccess.GetOwnWaypoints();
+
+            double closestWpDistance = double.MaxValue;
+            int closestWpIndex = -1;
+
+            for (int i = 0; i < ownWaypoints.Count; i++)
+            {
+                Waypoint wp = ownWaypoints[i];
+                if (wp.Position == null)
+                    continue;
+
+                if (ClientWaypointAccess.IsPendingDeletion(wp))
+                    continue;  // Already queued for removal - don't delete it twice
+
+                if (titlePattern != null && (wp.Title == null || !wp.Title.Contains(titlePattern)))
+                    continue;
+
+                double thisDist = searchPosition.DistanceTo(wp.Position);
+                if (thisDist > maxRadius)
+                    continue;
+
+                if (thisDist < closestWpDistance)
+                {
+                    closestWpDistance = thisDist;
+                    closestWpIndex = i;
+                }
+            }
+
+            if (closestWpIndex < 0)
+            {
+                if (titlePattern == null && maxRadius == double.MaxValue)
+                {
+                    MessageUtil.Log("Tried to delete the nearest map marker, but no waypoints owned by this player were found.");
+                }
+                return;
+            }
+
+            Waypoint target = ownWaypoints[closestWpIndex];
+
+            // The server indexes into this same owner-filtered list, but it will have processed any
+            // deletion we queued earlier first, and every removal shifts the later indices down one.
+            int commandIndex = closestWpIndex;
+            for (int i = 0; i < closestWpIndex; i++)
+            {
+                if (ClientWaypointAccess.IsPendingDeletion(ownWaypoints[i]))
+                    commandIndex--;
+            }
+
+            ClientWaypointAccess.AddPendingDeletion(target);
+            ClientWaypointAccess.DropPendingNear(target.Position, 1.0);
+            Enqueue($"/waypoint remove {commandIndex}", sendChatMessageToPlayer);
+        }
+
+        /// <summary>
+        /// Applies the same "don't mark the same spot twice" rule as WaypointUtil.AddWaypoint, but
+        /// against the player's client-synced waypoints plus any waypoint we've requested and the
+        /// server hasn't echoed back yet.
+        /// </summary>
+        private static bool IsCoveredByExistingWaypoint(Vec3d position, string title, string icon, AutoMapMarkerSetting settings)
+        {
+            int? settingColor = settings.MarkerColorInteger;
+
+            foreach (Waypoint waypoint in ClientWaypointAccess.GetOwnWaypoints())
+            {
+                if (waypoint.Position == null)
+                    continue;
+                if (ClientWaypointAccess.IsPendingDeletion(waypoint))
+                    continue;  // On its way out, so it shouldn't block a new marker here
+                if (!WithinCoverage(waypoint.Position, position, settings.MarkerCoverageRadius))
+                    continue;
+                if (WaypointUtil.MatchingWaypointTitle(waypoint.Title, title)
+                    && waypoint.Icon == icon
+                    && (settingColor == null || waypoint.Color == settingColor))
+                {
+                    return true;
+                }
+            }
+
+            foreach (var pending in ClientWaypointAccess.GetPending())
+            {
+                if (!WithinCoverage(pending.Position, position, settings.MarkerCoverageRadius))
+                    continue;
+                if (WaypointUtil.MatchingWaypointTitle(pending.Title, title)
+                    && pending.Icon == icon
+                    && (settingColor == null || pending.Color == settingColor))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool WithinCoverage(Vec3d existing, Vec3d candidate, int coverageRadius)
+        {
+            double xDiff = Math.Abs(existing.X - candidate.X);
+            double zDiff = Math.Abs(existing.Z - candidate.Z);
+            return Math.Max(xDiff, zDiff) < coverageRadius;
+        }
+
+        /// <summary>
+        /// The title is the trailing argument of the command, so spaces are fine, but line breaks
+        /// would truncate or split the command.
+        /// </summary>
+        private static string SanitizeTitle(string title)
+        {
+            if (string.IsNullOrEmpty(title))
+                return title;
+            return title.Replace('\r', ' ').Replace('\n', ' ').Trim();
+        }
+
+        /// <summary>
+        /// The game's color argument accepts either a hex value or a known .NET color name, which is
+        /// exactly what AutoMapMarkerSetting.MarkerColor already stores. Falls back to hex derived
+        /// from the parsed color if the stored value isn't a single token.
+        /// </summary>
+        private static string SanitizeColor(AutoMapMarkerSetting settings)
+        {
+            string color = settings.MarkerColor?.Trim();
+            if (!string.IsNullOrEmpty(color) && !color.Any(char.IsWhiteSpace))
+                return color;
+
+            int? colorInt = settings.MarkerColorIntegerNoAlpha;
+            if (colorInt == null)
+                return null;
+
+            return "#" + (colorInt.Value & 0xFFFFFF).ToString("X6", CultureInfo.InvariantCulture);
+        }
+
+        private static void Enqueue(string command, bool sendChatMessageToPlayer)
+        {
+            if (commandQueue.Count >= MaxQueuedCommands)
+            {
+                if (!queueOverflowLogged)
+                {
+                    queueOverflowLogged = true;
+                    MessageUtil.LogError($"Map marker command queue is full ({MaxQueuedCommands}) - dropping requests.");
+                }
+                return;
+            }
+            queueOverflowLogged = false;
+
+            commandQueue.Add(new QueuedCommand
+            {
+                Command = command,
+                // The server answers every waypoint command with a chat confirmation. Suppress it
+                // unless the player asked to be notified, in which case the vanilla message is the
+                // notification.
+                SuppressServerReply = !sendChatMessageToPlayer
+            });
+        }
+
+        private static void DrainQueue(float dt)
+        {
+            if (commandQueue.Count == 0)
+                return;
+
+            ICoreClientAPI capi = MapMarkerMod.CoreClientAPI;
+            if (capi == null)
+            {
+                commandQueue.Clear();
+                return;
+            }
+
+            QueuedCommand queued = commandQueue[0];
+            commandQueue.RemoveAt(0);
+
+            // Armed here rather than at enqueue time so the suppression window tracks the actual
+            // send, not however long the command sat in the queue.
+            if (queued.SuppressServerReply)
+                ChatSuppression.ArmSuppression();
+
+            capi.SendChatMessage(queued.Command, GlobalConstants.GeneralChatGroup, null);
+        }
+    }
+}


### PR DESCRIPTION
Currently the mod requires installing on both client and server. This adds
a fallback: when no server-side install is detected, waypoint create/delete
requests are fulfilled entirely client-side using the vanilla waypoint chat
commands instead of going over the mod's network channel. A Harmony patch
suppresses the resulting chat spam. modinfo's requiredOnServer is set to
false so it can be installed client-side only.

If the mod IS present on the server, nothing changes — the existing
network-channel p

Happy to adjust anything (naming, version bump, etc.) per your preference.

Your clientside-only branch (with the modid rename / rebranded icon / fork READMwn release — thisdoesn't affect that.